### PR TITLE
Fixed a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Platform | Build Status |
 Visual Studio 2013 | [AppVeyor](http://ci.appveyor.com/): [![Build status](https://ci.appveyor.com/api/projects/status/26ad7w3kx1e7w27h?svg=true)](https://ci.appveyor.com/project/sgorsten/json) |
 GCC 4.8 | [Travis CI](http://travis-ci.org): [![Build status](http://travis-ci.org/sgorsten/json.svg?branch=master)](https://travis-ci.org/sgorsten/json) |
 
-[json.h](http://raw.githubusercontent.com/sgorsten/linalg/master/json.h) is a [single header](http://github.com/nothings/stb/blob/master/docs/other_libs.md) [public domain](http://unlicense.org/) [JSON](http://json.org) library for [C++11](http://en.cppreference.com/w/). 
+[json.h](/json.h) is a [single header](http://github.com/nothings/stb/blob/master/docs/other_libs.md) [public domain](http://unlicense.org/) [JSON](http://json.org) library for [C++11](http://en.cppreference.com/w/). 
 
 # TODO
 


### PR DESCRIPTION
Just a tiny `README.md` change. I've also changed it to use [GitHub's file-linking syntax](https://github.com/blog/1395-relative-links-in-markup-files) instead of linking directly to the raw URL.
